### PR TITLE
Added film keyword to GifyUrl

### DIFF
--- a/script.js
+++ b/script.js
@@ -146,7 +146,7 @@ var createsURL = (function() {
     }
 
     function generateGifUrl(movie) {
-        var url = 'http://api.giphy.com/v1/gifs/search?q=&api_key=dc6zaTOxFJmzC&lang=en&limit=3&q=' + encodeURIComponent(movie);
+        var url = 'http://api.giphy.com/v1/gifs/search?q=&api_key=dc6zaTOxFJmzC&lang=en&limit=3&q=' + encodeURIComponent(movie+'film');
         return url;
     }
 


### PR DESCRIPTION
We've added the string film when we call the gify-api url to make the gifys more related to the film. Related to issue #64 .